### PR TITLE
Return all facilities when the event is rerated to multi facilities

### DIFF
--- a/garoonbot/schedule.py
+++ b/garoonbot/schedule.py
@@ -67,9 +67,9 @@ def get_facility(event):
     Returns:
         str: Facility name
     """
-    elm = event.xpath('.//*[local-name()="facility"]')
-    if elm:
-        return elm[0].attrib['name']
+    elms = event.xpath('.//*[local-name()="facility"]')
+    if elms:
+        return ', '.join([x.attrib['name'] for x in elms])
     return ''
 
 


### PR DESCRIPTION
予定が複数の施設と紐づけられている場合に、最初のひとつしか返していないのを修正。

カンマ区切りで文字列として返すだけだが、実用上はひとまずこれで十分だろう。